### PR TITLE
Made kattis.py executable on unix systems.

### DIFF
--- a/kattis.py
+++ b/kattis.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys, os, requests, zipfile, io, shutil, subprocess
 
 def getBytesFromFile(file):


### PR DESCRIPTION
This simple change allows unix users to execute the kattis.py file directly, without the need of extra files (such as the kattis.sh). We could even delete kattis.sh if you want.

It shoudn't interfere with windows users, but to be sure it should ofc be tested before merging.