### PR TITLE
Fix boilerplate

### DIFF
--- a/kattis.py
+++ b/kattis.py
@@ -16,7 +16,7 @@ def get(args):
     z = zipfile.ZipFile(io.BytesIO(r.content))
     os.makedirs(args[0])
     z.extractall(args[0] + "/test")
-    shutil.copy2("boilerplate.py", args[0] + "/" + args[0] + ".py")
+    shutil.copy2(os.path.dirname(os.path.realpath(__file__)) + "/boilerplate.py", args[0] + "/" + args[0] + ".py")
     print("Successfully initialized exercise", args[0] + "!")
     print("You can test your script with 'kattis test " + args[0] + "'")
 


### PR DESCRIPTION
Fixed boilerplate creation when the katttis.py script  is called from another directory.

This is solved by getting the absolute path of the folder where the script is located.